### PR TITLE
feat: implement Objective-C calling Zig

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,32 +2,20 @@ on: [push, pull_request]
 name: Test
 jobs:
   build:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-
-        target: [
-          aarch64-macos,
-          x86_64-macos,
-        ]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-12
     env:
       # Needed for macos SDK
       AGREE: "true"
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    # Install Nix and use that to run our tests so our environment matches exactly.
-    - uses: cachix/install-nix-action@v18
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
+      # Install Nix and use that to run our tests so our environment matches exactly.
+      - uses: cachix/install-nix-action@v23
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
 
-    # Cross-compile the binary. We always use static building for this
-    # because its the only way to access the headers.
-    - name: Test Build
-      run: nix develop -c zig build -Dtarget=${{ matrix.target }}
+      # Cross-compile the binary. We always use static building for this
+      # because its the only way to access the headers.
+      - name: Test
+        run: nix develop -c zig build test --summary all

--- a/build.zig
+++ b/build.zig
@@ -1,6 +1,6 @@
 const std = @import("std");
 
-pub fn build(b: *std.Build) !void {
+pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
@@ -15,6 +15,7 @@ pub fn build(b: *std.Build) !void {
     tests.linkSystemLibrary("objc");
     tests.linkFramework("Foundation");
     @import("macos_sdk").addPaths(tests);
+
     b.installArtifact(tests);
 
     const test_step = b.step("test", "Run tests");

--- a/build.zig
+++ b/build.zig
@@ -15,7 +15,6 @@ pub fn build(b: *std.Build) void {
     tests.linkSystemLibrary("objc");
     tests.linkFramework("Foundation");
     @import("macos_sdk").addPaths(tests);
-
     b.installArtifact(tests);
 
     const test_step = b.step("test", "Run tests");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,4 @@
 .{
-    .paths = .{"src"},
     .name = "zig-objc",
     .version = "0.0.0",
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,4 +1,5 @@
 .{
+    .paths = .{"src"},
     .name = "zig-objc",
     .version = "0.0.0",
     .paths = .{

--- a/src/block.zig
+++ b/src/block.zig
@@ -1,0 +1,319 @@
+const std = @import("std");
+const objc = @import("main.zig");
+
+const NSConcreteStackBlock = @extern(*anyopaque, .{
+    .name = "_NSConcreteStackBlock",
+});
+
+extern "C" fn _Block_object_assign(dst: *anyopaque, src: *const anyopaque, flag: c_int) void;
+extern "C" fn _Block_object_dispose(src: *const anyopaque, flag: c_int) void;
+
+/// captures is either a struct type or a struct literal
+// whose fields will be added to the block
+// captures should not be a tuple
+// blockFn is either a function type or an actual function
+pub fn Block(comptime captures: anytype, comptime blockFn: anytype) type {
+    const Captures = @TypeOf(captures);
+    const BlockFn = @TypeOf(blockFn);
+    const captures_info = @typeInfo(Captures);
+    const blockfn_info = @typeInfo(BlockFn);
+    const real_captures_info = switch (captures_info) {
+        .Type => @typeInfo(captures).Struct,
+        .Struct => |s| s,
+        else => @compileError("captures should be a struct type or struct literal"),
+    };
+    const real_blockfn_info = switch (blockfn_info) {
+        .Type => @typeInfo(blockFn).Fn,
+        .Fn => |f| f,
+        .Pointer => |p| @typeInfo(p.child).Fn,
+        else => @compileError("blockFn should be a function type or a function"),
+    };
+    const Return = real_blockfn_info.return_type.?;
+    const params = real_blockfn_info.params;
+    // an invoke function takes at least one argument: a block.
+    std.debug.assert(params.len > 0);
+    // an invoke function's first argument, a block, must be *anyopaque.
+    std.debug.assert(params[0].type == *anyopaque);
+    const fields: []std.builtin.Type.StructField = fields: {
+        var acc: [real_captures_info.fields.len + 5]std.builtin.Type.StructField = undefined;
+        acc[0] = .{
+            .name = "isa",
+            .type = ?*anyopaque,
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = @alignOf(*anyopaque),
+        };
+        acc[1] = .{
+            .name = "flags",
+            .type = c_int,
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = @alignOf(c_int),
+        };
+        acc[2] = .{
+            .name = "reserved",
+            .type = c_int,
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = @alignOf(c_int),
+        };
+        acc[3] = .{
+            .name = "invoke",
+            .type = *const @Type(.{
+                .Fn = .{
+                    .calling_convention = .C,
+                    .alignment = @typeInfo(fn () callconv(.C) void).Fn.alignment,
+                    .is_generic = false,
+                    .is_var_args = false,
+                    .return_type = Return,
+                    .params = params,
+                },
+            }),
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = @typeInfo(*const fn () callconv(.C) void).Pointer.alignment,
+        };
+        acc[4] = .{
+            .name = "descriptor",
+            .type = *Descriptor,
+            .default_value = null,
+            .is_comptime = false,
+            .alignment = @alignOf(*Descriptor),
+        };
+        std.debug.assert(!real_captures_info.is_tuple);
+        for (real_captures_info.fields, 0..) |capture, i| {
+            switch (capture.type) {
+                comptime_int => @compileError("capture should not be a comptime_int! try using @as"),
+                comptime_float => @compileError("capture should not be a comptime_float! try using @as"),
+                else => {},
+            }
+            acc[5 + i] = .{
+                .name = capture.name,
+                .type = capture.type,
+                .default_value = null,
+                .is_comptime = false,
+                .alignment = capture.alignment,
+            };
+        }
+        break :fields &acc;
+    };
+    return @Type(.{
+        .Struct = .{
+            .layout = .Extern,
+            .fields = fields,
+            .decls = &.{},
+            .is_tuple = false,
+        },
+    });
+}
+
+/// creates a block (on the heap, using malloc) of type T,
+// which should be the output of Block,
+// assigns the given captures
+// (which should be a struct literal with correct names)
+// and assigns the given function
+// (which should have the correct signature and C calling convention)
+// to the block.
+// Objective-C will free block pointers itself,
+// otherwise you can call free on it yourself.
+pub fn initBlock(comptime T: type, captures: anytype, blockFn: anytype) *T {
+    const allocator = std.heap.raw_c_allocator;
+    var ret = allocator.create(T) catch @panic("OOM!");
+    const captures_info = @typeInfo(@TypeOf(captures)).Struct;
+    var fn_is_pointer = false;
+    const fn_info = switch (@typeInfo(@TypeOf(blockFn))) {
+        .Fn => |f| f,
+        .Pointer => |p| blk: {
+            fn_is_pointer = true;
+            break :blk @typeInfo(p.child).Fn;
+        },
+        else => @compileError("blockFn should be a function!"),
+    };
+    std.debug.assert(fn_info.calling_convention == .C);
+    const Return = fn_info.return_type.?;
+    const ret_type = @typeInfo(Return);
+    const flags: BlockFlags = .{
+        .stret = ret_type == .Struct,
+    };
+    @field(ret, "isa") = NSConcreteStackBlock;
+    @field(ret, "flags") = @as(c_int, @bitCast(flags));
+    @field(ret, "reserved") = undefined;
+    @field(ret, "invoke") = if (fn_is_pointer) blockFn else &blockFn;
+    const inner = struct {
+        fn copy_helper(src: *anyopaque, dst: *anyopaque) callconv(.C) void {
+            var real_src: *T = @ptrCast(@alignCast(src));
+            var real_dst: *T = @ptrCast(@alignCast(dst));
+            inline for (captures_info.fields) |field| {
+                if (field.type == objc.c.id) {
+                    var dst_field = @field(real_dst, field.name);
+                    const src_field = @field(real_src, field.name);
+                    _Block_object_assign(dst_field, src_field, 3);
+                }
+            }
+        }
+        fn dispose_helper(src: *anyopaque) callconv(.C) void {
+            const real_src: *T = @ptrCast(@alignCast(src));
+            inline for (captures_info.fields) |field| {
+                if (field.type == objc.c.id) {
+                    _Block_object_dispose(@field(real_src, field.name), 3);
+                }
+                std.heap.raw_c_allocator.free(std.mem.sliceTo(@field(@field(real_src, "descriptor"), "signature").?, 0));
+                std.heap.raw_c_allocator.destroy(@field(real_src, "descriptor"));
+            }
+        }
+    };
+    const signature = encodeFn(Return, fn_info.params) catch @panic("OOM!");
+    var descriptor = allocator.create(Descriptor) catch @panic("OOM!");
+    descriptor.* = .{
+        .reserved = 0,
+        .size = @sizeOf(T),
+        .copy_helper = inner.copy_helper,
+        .dispose_helper = inner.dispose_helper,
+        .signature = signature.ptr,
+    };
+    @field(ret, "descriptor") = descriptor;
+    inline for (captures_info.fields) |field| {
+        @field(ret, field.name) = @field(captures, field.name);
+    }
+    return ret;
+}
+
+/// contents must be freed with 'free'
+pub fn encodeFn(
+    comptime Return: type,
+    comptime Args: []const std.builtin.Type.Fn.Param,
+) ![:0]const u8 {
+    var allocator = std.heap.raw_c_allocator;
+    const String = std.ArrayList(u8);
+    var list = try String.initCapacity(allocator, 1024);
+    defer list.deinit();
+    const str = try encode_inner(Return);
+    try list.appendSlice(str);
+    allocator.free(str);
+    inline for (Args) |arg| {
+        const arg_str = try encode_inner(arg.type.?);
+        defer allocator.free(arg_str);
+        try list.appendSlice(arg_str);
+    }
+    return allocator.dupeZ(u8, list.items);
+}
+
+fn encode_inner(comptime T: type) ![]const u8 {
+    var allocator = std.heap.raw_c_allocator;
+    const String = std.ArrayList(u8);
+    var list = try String.initCapacity(allocator, 128);
+    defer list.deinit();
+    switch (T) {
+        objc.Object, objc.c.id => try list.append('@'),
+        objc.Class, objc.c.Class => try list.append('#'),
+        objc.Sel, objc.c.SEL => try list.append(':'),
+        bool => try list.append('B'),
+        u8 => try list.append('C'),
+        i8 => try list.append('c'),
+        u16 => try list.append('S'),
+        i16 => try list.append('s'),
+        u32, c_uint => try list.append('I'),
+        i32, c_int => try list.append('i'),
+        u64, c_ulong, c_ulonglong => try list.append('Q'),
+        i64, c_long, c_longlong => try list.append('q'),
+        f32 => try list.append('f'),
+        f64 => try list.append('d'),
+        [:0]const u8, [*c]const u8, [:0]u8, [*c]u8 => try list.append('*'),
+        void => try list.append('v'),
+        else => {
+            const type_info = @typeInfo(T);
+            switch (type_info) {
+                .Struct => |s| {
+                    try list.appendSlice("{?=");
+                    for (s.fields) |field| {
+                        const str = try encode_inner(field.type);
+                        defer allocator.free(str);
+                        try list.appendSlice(str);
+                    }
+                    try list.appendSlice("}");
+                },
+                .Union => |u| {
+                    try list.appendSlice("(?=");
+                    for (u.fields) |field| {
+                        const str = try encode_inner(field.type);
+                        defer allocator.free(str);
+                        try list.appendSlice(str);
+                    }
+                    try list.appendSlice(")");
+                },
+                .Pointer => |p| {
+                    try list.append('^');
+                    const str = try encode_inner(p.child);
+                    defer allocator.free(str);
+                    try list.appendSlice(str);
+                },
+                .Fn => try list.append('?'),
+                .Opaque => try list.append('v'),
+                else => @compileError("unsupported type for encode(): " ++ @typeName(T)),
+            }
+        },
+    }
+    return allocator.dupe(u8, list.items);
+}
+
+/// contents must be freed with 'free'
+pub fn encode(comptime T: type) ![:0]const u8 {
+    const allocator = std.heap.raw_c_allocator;
+    const str = try encode_inner(T);
+    defer allocator.free(str);
+    return allocator.dupeZ(u8, str);
+}
+
+const Descriptor = extern struct {
+    reserved: c_ulong = 0,
+    size: c_ulong,
+    copy_helper: *const fn (dst: *anyopaque, src: *anyopaque) callconv(.C) void,
+    dispose_helper: *const fn (src: *anyopaque) callconv(.C) void,
+    signature: ?[*:0]const u8,
+};
+
+const BlockFlags = packed struct {
+    _unused: u22 = 0,
+    noescape: bool = false,
+    _unused_2: bool = false,
+    copy_dispose: bool = true,
+    ctor: bool = false,
+    _unused_3: bool = false,
+    global: bool = false,
+    stret: bool,
+    signature: bool = true,
+    _unused_4: u2 = 0,
+
+    comptime {
+        std.debug.assert(@sizeOf(@This()) == @sizeOf(c_int));
+        std.debug.assert(@bitSizeOf(@This()) == @bitSizeOf(c_int));
+    }
+};
+
+pub fn invokeBlock(comptime T: type, comptime Return: type, block: *T, args: anytype) Return {
+    var invoke = @field(block, "invoke");
+    const ret: Return = @call(.auto, invoke, .{block} ++ args);
+    return ret;
+}
+
+test "Block and invokeBlock" {
+    const Captures = struct {
+        x: i32,
+        y: i32,
+    };
+    const AddBlock = Block(Captures, fn (block: *anyopaque) i32);
+    const captures = .{
+        .x = 2,
+        .y = 3,
+    };
+    const inner = struct {
+        fn addFn(block: *anyopaque) callconv(.C) i32 {
+            const realBlock: *AddBlock = @ptrCast(@alignCast(block));
+            return realBlock.x + realBlock.y;
+        }
+    };
+    var block = initBlock(AddBlock, captures, inner.addFn);
+    defer std.heap.raw_c_allocator.destroy(block);
+    const ret = invokeBlock(AddBlock, i32, block, .{});
+    try std.testing.expectEqual(@as(i32, 5), ret);
+}

--- a/src/block.zig
+++ b/src/block.zig
@@ -1,10 +1,7 @@
 const std = @import("std");
 const objc = @import("main.zig");
 
-const NSConcreteStackBlock = @extern(*anyopaque, .{
-    .name = "_NSConcreteStackBlock",
-});
-
+const NSConcreteStackBlock = @extern(*anyopaque, .{ .name = "_NSConcreteStackBlock" });
 extern "C" fn _Block_object_assign(dst: *anyopaque, src: *const anyopaque, flag: c_int) void;
 extern "C" fn _Block_object_dispose(src: *const anyopaque, flag: c_int) void;
 

--- a/src/class.zig
+++ b/src/class.zig
@@ -78,7 +78,14 @@ pub const Class = struct {
     // only call this function between allocateClassPair and registerClassPair
     // this adds an Ivar of type `id`.
     pub fn addIvar(self: Class, name: [:0]const u8) bool {
-        return c.class_addIvar(self.value, name, @sizeOf(c.id), @alignOf(c.id), "@");
+        // The return type is i8 when we're cross compiling, unsure why.
+        const fn_info = @typeInfo(@TypeOf(c.class_addIvar)).Fn;
+        const result = c.class_addIvar(self.value, name, @sizeOf(c.id), @alignOf(c.id), "@");
+        return switch (fn_info.return_type.?) {
+            bool => result,
+            i8 => result == 1,
+            else => @compileError("unhandled class_addIvar return type"),
+        };
     }
 };
 

--- a/src/class.zig
+++ b/src/class.zig
@@ -126,17 +126,17 @@ test "msgSend" {
     const NSObject = getClass("NSObject").?;
 
     // Should work with primitives
-    const id = NSObject.message(c.id, "alloc", .{});
+    const id = NSObject.msgSend(c.id, "alloc", .{});
     try testing.expect(id != null);
     {
         const obj: objc.Object = .{ .value = id };
-        obj.message(void, "dealloc", .{});
+        obj.msgSend(void, "dealloc", .{});
     }
 
     // Should work with our wrappers
-    const obj = NSObject.message(objc.Object, "alloc", .{});
+    const obj = NSObject.msgSend(objc.Object, "alloc", .{});
     try testing.expect(obj.value != null);
-    obj.message(void, "dealloc", .{});
+    obj.msgSend(void, "dealloc", .{});
 }
 
 test "getProperty" {
@@ -170,10 +170,10 @@ test "allocatecClassPair and replaceMethod" {
     registerClassPair(my_object);
     defer disposeClassPair(my_object);
     const object: objc.Object = .{
-        .value = my_object.message(c.id, "alloc", .{}),
+        .value = my_object.msgSend(c.id, "alloc", .{}),
     };
-    defer object.message(void, "dealloc", .{});
-    try testing.expectEqual(@as(u64, 69), object.message(u64, "hash", .{}));
+    defer object.msgSend(void, "dealloc", .{});
+    try testing.expectEqual(@as(u64, 69), object.msgSend(u64, "hash", .{}));
 }
 
 test "Ivars" {
@@ -184,12 +184,12 @@ test "Ivars" {
     registerClassPair(my_object);
     defer disposeClassPair(my_object);
     const object: objc.Object = .{
-        .value = my_object.message(c.id, "alloc", .{}),
+        .value = my_object.msgSend(c.id, "alloc", .{}),
     };
-    defer object.message(void, "dealloc", .{});
+    defer object.msgSend(void, "dealloc", .{});
     const NSString = getClass("NSString").?;
-    const my_string = NSString.message(objc.Object, "stringWithUTF8String:", .{"69---nice"});
-    defer my_string.message(void, "dealloc", .{});
+    const my_string = NSString.msgSend(objc.Object, "stringWithUTF8String:", .{"69---nice"});
+    defer my_string.msgSend(void, "dealloc", .{});
     object.setInstanceVariable("my_ivar", my_string);
     const my_ivar = object.getInstanceVariable("my_ivar");
     const slice = std.mem.sliceTo(my_ivar.getProperty([*c]const u8, "UTF8String"), 0);

--- a/src/class.zig
+++ b/src/class.zig
@@ -5,17 +5,9 @@ const MsgSend = @import("msg_send.zig").MsgSend;
 
 pub const Class = struct {
     value: c.Class,
-
     pub usingnamespace MsgSend(Class);
 
-    /// Returns the class definition of a specified class.
-    pub fn getClass(name: [:0]const u8) ?Class {
-        return Class{
-            .value = c.objc_getClass(name.ptr) orelse return null,
-        };
-    }
-
-    /// Returns a property with a given name of a given class.
+    // Returns a property with a given name of a given class.
     pub fn getProperty(self: Class, name: [:0]const u8) ?objc.Property {
         return objc.Property{
             .value = c.class_getProperty(self.value, name.ptr) orelse return null,
@@ -29,36 +21,126 @@ pub const Class = struct {
         if (count == 0) return list[0..0];
         return list[0..count];
     }
+
+    /// Describes the protocols adopted by a class. This must be freed.
+    pub fn copyProtocolList(self: Class) []objc.Protocol {
+        var count: c_uint = undefined;
+        const list = @as([*c]objc.Protocol, @ptrCast(c.class_copyProtocolList(self.value, &count)));
+        if (count == 0) return list[0..0];
+        return list[0..count];
+    }
+
+    pub fn isMetaClass(self: Class) bool {
+        return if (c.class_isMetaClass(self.value) == 1) true else false;
+    }
+
+    pub fn getInstanceSize(self: Class) usize {
+        return c.class_getInstanceSize(self.value);
+    }
+
+    pub fn respondsToSelector(self: Class, sel: objc.Sel) bool {
+        return if (c.class_respondsToSelector(self.value, sel.value) == 1) true else false;
+    }
+
+    pub fn conformsToProtocol(self: Class, protocol: objc.Protocol) bool {
+        return if (c.class_conformsToProtocol(self.value, &protocol.value) == 1) true else false;
+    }
+
+    // currently only allows for overriding methods previously defined, e.g. by a superclass.
+    // imp should be a function with C calling convention
+    // whose first two arguments are a `c.id` and a `c.SEL`.
+    pub fn replaceMethod(self: Class, name: [:0]const u8, imp: anytype) void {
+        const type_info = @typeInfo(@TypeOf(imp));
+        switch (type_info) {
+            .Fn => |fn_info| {
+                std.debug.assert(fn_info.calling_convention == .C);
+                std.debug.assert(fn_info.is_var_args == false);
+                std.debug.assert(fn_info.params.len >= 2);
+                std.debug.assert(fn_info.params[0].type == c.id);
+                std.debug.assert(fn_info.params[1].type == c.SEL);
+            },
+            else => unreachable,
+        }
+        _ = c.class_replaceMethod(self.value, objc.sel(name).value, @ptrCast(&imp), null);
+    }
+
+    /// allows adding new methods; returns true on success.
+    // imp should be a function with C calling convention
+    // whose first two arguments are a `c.id` and a `c.SEL`.
+    pub fn addMethod(self: Class, name: [:0]const u8, imp: anytype) bool {
+        const fn_info = @typeInfo(@TypeOf(imp)).Fn;
+        std.debug.assert(fn_info.calling_convention == .C);
+        std.debug.assert(fn_info.is_var_args == false);
+        std.debug.assert(fn_info.params.len >= 2);
+        std.debug.assert(fn_info.params[0].type == c.id);
+        std.debug.assert(fn_info.params[1].type == c.SEL);
+        const str = objc.encodeFn(fn_info.return_type.?, fn_info.params);
+        defer std.heap.raw_c_allocator.free(str);
+        return c.class_addMethod(self.value, objc.sel(name).value, @ptrCast(&imp), str);
+    }
+
+    // only call this function between allocateClassPair and registerClassPair
+    // this adds an Ivar of type `id`.
+    pub fn addIvar(self: Class, name: [:0]const u8) bool {
+        return c.class_addIvar(self.value, name, @sizeOf(c.id), @alignOf(c.id), "@");
+    }
 };
+
+pub fn getClass(name: [:0]const u8) ?Class {
+    return .{
+        .value = c.objc_getClass(name.ptr) orelse return null,
+    };
+}
+
+pub fn getMetaClass(name: [:0]const u8) ?Class {
+    return .{
+        .value = c.objc_getMetaClass(name) orelse return null,
+    };
+}
+
+// begin by calling this function, then call registerClassPair on the result when you are finished
+pub fn allocateClassPair(superclass: ?Class, name: [:0]const u8) ?Class {
+    return .{
+        .value = c.objc_allocateClassPair(if (superclass) |cls| cls.value else null, name.ptr, 0) orelse return null,
+    };
+}
+
+pub fn registerClassPair(class: Class) void {
+    c.objc_registerClassPair(class.value);
+}
+
+pub fn disposeClassPair(class: Class) void {
+    c.objc_disposeClassPair(class.value);
+}
 
 test "getClass" {
     const testing = std.testing;
-    const NSObject = Class.getClass("NSObject");
+    const NSObject = getClass("NSObject");
     try testing.expect(NSObject != null);
-    try testing.expect(Class.getClass("NoWay") == null);
+    try testing.expect(getClass("NoWay") == null);
 }
 
 test "msgSend" {
     const testing = std.testing;
-    const NSObject = Class.getClass("NSObject").?;
+    const NSObject = getClass("NSObject").?;
 
     // Should work with primitives
-    const id = NSObject.msgSend(c.id, objc.Sel.registerName("alloc"), .{});
+    const id = NSObject.message(c.id, "alloc", .{});
     try testing.expect(id != null);
     {
         const obj: objc.Object = .{ .value = id };
-        obj.msgSend(void, objc.sel("dealloc"), .{});
+        obj.message(void, "dealloc", .{});
     }
 
     // Should work with our wrappers
-    const obj = NSObject.msgSend(objc.Object, objc.Sel.registerName("alloc"), .{});
+    const obj = NSObject.message(objc.Object, "alloc", .{});
     try testing.expect(obj.value != null);
-    obj.msgSend(void, objc.sel("dealloc"), .{});
+    obj.message(void, "dealloc", .{});
 }
 
 test "getProperty" {
     const testing = std.testing;
-    const NSObject = Class.getClass("NSObject").?;
+    const NSObject = getClass("NSObject").?;
 
     try testing.expect(NSObject.getProperty("className") != null);
     try testing.expect(NSObject.getProperty("nope") == null);
@@ -66,9 +148,49 @@ test "getProperty" {
 
 test "copyProperyList" {
     const testing = std.testing;
-    const NSObject = Class.getClass("NSObject").?;
+    const NSObject = getClass("NSObject").?;
 
     const list = NSObject.copyPropertyList();
     defer objc.free(list);
     try testing.expect(list.len > 0);
+}
+
+test "allocatecClassPair and replaceMethod" {
+    const testing = std.testing;
+    const NSObject = getClass("NSObject").?;
+    var my_object = allocateClassPair(NSObject, "my_object").?;
+    my_object.replaceMethod("hash", struct {
+        fn inner(target: c.id, sel: c.SEL) callconv(.C) u64 {
+            _ = sel;
+            _ = target;
+            return 69;
+        }
+    }.inner);
+    registerClassPair(my_object);
+    defer disposeClassPair(my_object);
+    const object: objc.Object = .{
+        .value = my_object.message(c.id, "alloc", .{}),
+    };
+    defer object.message(void, "dealloc", .{});
+    try testing.expectEqual(@as(u64, 69), object.message(u64, "hash", .{}));
+}
+
+test "Ivars" {
+    const testing = std.testing;
+    const NSObject = getClass("NSObject").?;
+    var my_object = allocateClassPair(NSObject, "my_object").?;
+    try testing.expectEqual(true, my_object.addIvar("my_ivar"));
+    registerClassPair(my_object);
+    defer disposeClassPair(my_object);
+    const object: objc.Object = .{
+        .value = my_object.message(c.id, "alloc", .{}),
+    };
+    defer object.message(void, "dealloc", .{});
+    const NSString = getClass("NSString").?;
+    const my_string = NSString.message(objc.Object, "stringWithUTF8String:", .{"69---nice"});
+    defer my_string.message(void, "dealloc", .{});
+    object.setInstanceVariable("my_ivar", my_string);
+    const my_ivar = object.getInstanceVariable("my_ivar");
+    const slice = std.mem.sliceTo(my_ivar.getProperty([*c]const u8, "UTF8String"), 0);
+    try testing.expectEqualSlices(u8, "69---nice", slice);
 }

--- a/src/class.zig
+++ b/src/class.zig
@@ -74,9 +74,9 @@ pub const Class = struct {
         std.debug.assert(fn_info.params.len >= 2);
         std.debug.assert(fn_info.params[0].type == c.id);
         std.debug.assert(fn_info.params[1].type == c.SEL);
-        const str = objc.encodeFn(fn_info.return_type.?, fn_info.params);
+        const str = objc.encodeFn(fn_info.return_type.?, fn_info.params) catch @panic("OOM!");
         defer std.heap.raw_c_allocator.free(str);
-        return c.class_addMethod(self.value, objc.sel(name).value, @ptrCast(&imp), str);
+        return c.class_addMethod(self.value, objc.sel(name).value, @ptrCast(&imp), str.ptr);
     }
 
     // only call this function between allocateClassPair and registerClassPair

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,7 +5,9 @@ pub usingnamespace @import("autorelease.zig");
 pub usingnamespace @import("class.zig");
 pub usingnamespace @import("object.zig");
 pub usingnamespace @import("property.zig");
+pub usingnamespace @import("protocol.zig");
 pub usingnamespace @import("sel.zig");
+pub usingnamespace @import("block.zig");
 
 /// This just calls the C allocator free. Some things need to be freed
 /// and this is how they can be freed for objc.

--- a/src/msg_send.zig
+++ b/src/msg_send.zig
@@ -21,6 +21,7 @@ pub fn MsgSend(comptime T: type) type {
         ) Return {
             return @This().msgSendSuper(target, superclass, Return, objc.sel(msg), args);
         }
+
         pub fn message(
             target: T,
             comptime Return: type,
@@ -29,6 +30,7 @@ pub fn MsgSend(comptime T: type) type {
         ) Return {
             return @This().msgSend(target, Return, objc.sel(msg), args);
         }
+
         /// Invoke a selector on the target, i.e. an instance method on an
         /// object or a class method on a class. The args should be a tuple.
         pub fn msgSend(

--- a/src/object.zig
+++ b/src/object.zig
@@ -84,7 +84,7 @@ pub const Object = struct {
     }
 
     pub fn isClass(self: Object) bool {
-        return if (c.object_isClass(self.value) == 1) true else false;
+        return c.object_isClass(self.value) == 1;
     }
 
     pub fn getInstanceVariable(self: Object, name: [:0]const u8) Object {

--- a/src/object.zig
+++ b/src/object.zig
@@ -74,11 +74,33 @@ pub const Object = struct {
 
         return self.msgSend(T, getter, .{});
     }
+
+    pub fn copy(self: Object, size: usize) Object {
+        return fromId(c.object_copy(self.value, size));
+    }
+
+    pub fn dispose(self: Object) void {
+        c.object_dispose(self.value);
+    }
+
+    pub fn isClass(self: Object) bool {
+        return if (c.object_isClass(self.value) == 1) true else false;
+    }
+
+    pub fn getInstanceVariable(self: Object, name: [:0]const u8) Object {
+        const ivar = c.object_getInstanceVariable(self.value, name, null);
+        return fromId(c.object_getIvar(self.value, ivar));
+    }
+
+    pub fn setInstanceVariable(self: Object, name: [:0]const u8, val: Object) void {
+        const ivar = c.object_getInstanceVariable(self.value, name, null);
+        c.object_setIvar(self.value, ivar, val.value);
+    }
 };
 
 test {
     const testing = std.testing;
-    const NSObject = objc.Class.getClass("NSObject").?;
+    const NSObject = objc.getClass("NSObject").?;
 
     // Should work with our wrappers
     const obj = NSObject.msgSend(objc.Object, objc.Sel.registerName("alloc"), .{});

--- a/src/property.zig
+++ b/src/property.zig
@@ -17,6 +17,11 @@ pub const Property = extern struct {
             0,
         );
     }
+
+    comptime {
+        std.debug.assert(@sizeOf(@This()) == @sizeOf(c.objc_property_t));
+        std.debug.assert(@alignOf(@This()) == @alignOf(c.objc_property_t));
+    }
 };
 
 test {
@@ -28,7 +33,7 @@ test {
 
 test {
     const testing = std.testing;
-    const NSObject = objc.Class.getClass("NSObject").?;
+    const NSObject = objc.getClass("NSObject").?;
 
     const prop = NSObject.getProperty("className").?;
     try testing.expectEqualStrings("className", prop.getName());

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -6,23 +6,31 @@ pub const Protocol = extern struct {
     value: *c.Protocol,
 
     pub fn conformsToProtocol(self: Protocol, other: Protocol) bool {
-        return if (c.protocol_conformsToProtocol(self.value, other.value) == 1) true else false;
+        return c.protocol_conformsToProtocol(self.value, other.value) == 1;
     }
 
     pub fn isEqual(self: Protocol, other: Protocol) bool {
-        return if (c.protocol_isEqual(self.value, other.value) == 1) true else false;
+        return c.protocol_isEqual(self.value, other.value) == 1;
     }
 
     pub fn getName(self: Protocol) [:0]const u8 {
         return std.mem.sliceTo(c.protocol_getName(self.value), 0);
     }
 
-    pub fn getProperty(self: Protocol, name: [:0]const u8, is_required: bool, is_instance: bool) ?objc.Property {
+    pub fn getProperty(
+        self: Protocol,
+        name: [:0]const u8,
+        is_required: bool,
+        is_instance: bool,
+    ) ?objc.Property {
         const isRequired: u8 = if (is_required) 1 else 0;
         const isInstance: u8 = if (is_instance) 1 else 0;
-        return .{
-            .value = c.protocol_getProperty(self.value, name, isRequired, isInstance) orelse return null,
-        };
+        return .{ .value = c.protocol_getProperty(
+            self.value,
+            name,
+            isRequired,
+            isInstance,
+        ) orelse return null };
     }
 
     comptime {
@@ -32,7 +40,5 @@ pub const Protocol = extern struct {
 };
 
 pub fn getProtocol(name: [:0]const u8) ?Protocol {
-    return .{
-        .value = c.objc_getProtocol(name) orelse return null,
-    };
+    return .{ .value = c.objc_getProtocol(name) orelse return null };
 }

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -1,0 +1,38 @@
+const std = @import("std");
+const c = @import("c.zig");
+const objc = @import("main.zig");
+
+pub const Protocol = extern struct {
+    value: *c.Protocol,
+
+    pub fn conformsToProtocol(self: Protocol, other: Protocol) bool {
+        return if (c.protocol_conformsToProtocol(self.value, other.value) == 1) true else false;
+    }
+
+    pub fn isEqual(self: Protocol, other: Protocol) bool {
+        return if (c.protocol_isEqual(self.value, other.value) == 1) true else false;
+    }
+
+    pub fn getName(self: Protocol) [:0]const u8 {
+        return std.mem.sliceTo(c.protocol_getName(self.value), 0);
+    }
+
+    pub fn getProperty(self: Protocol, name: [:0]const u8, is_required: bool, is_instance: bool) ?objc.Property {
+        const isRequired: u8 = if (is_required) 1 else 0;
+        const isInstance: u8 = if (is_instance) 1 else 0;
+        return .{
+            .value = c.protocol_getProperty(self.value, name, isRequired, isInstance) orelse return null,
+        };
+    }
+
+    comptime {
+        std.debug.assert(@sizeOf(@This()) == @sizeOf([*c]c.Protocol));
+        std.debug.assert(@alignOf(@This()) == @alignOf([*c]c.Protocol));
+    }
+};
+
+pub fn getProtocol(name: [:0]const u8) ?Protocol {
+    return .{
+        .value = c.objc_getProtocol(name) orelse return null,
+    };
+}


### PR DESCRIPTION
this PR adds methods for Objective-C to call Zig code
with subclasses, instance variables, blocks and overriding methods.

i've been working through [a handful of toy Zig programs](https://github.com/ryleelyman/zig-cocoa-examples) with this library to explore writing macOS GUI code in pure Zig.
i'm loving how straightforward the library interface feels, thank you for such a thoughtful implementation!

anyway, along the way i've implemented some missing features that my toy programs called for.
here is a changelog:
_____

* breaking change: `Class.getClass -> getClass`. happy to re-add the ability to call `Class.getClass` if you'd like, but this felt needlessly verbose.
* added `message` as a slightly less verbose alternative to `msgSend`: instead of a `Sel` object, it takes in a string and creates the Sel itself.
* added basic protocol support sort of similar to the property support.
### subclasses
everything described here is newly added.
the workflow for registering one's own classes with the objective-C runtime is the following:
create the class with `allocateClassPair`. optionally add instance variables with `addIvar`,
or override class methods with `replaceMethod` or add your own with `addMethod`.
when you're ready for the class to be used, call `registerClassPair`.

* added `msgSendSuper`, which is mainly useful within user-defined methods.
### blocks
everything described here is newly added.
the workflow for creating one's own blocks is the following:
call `Block` with a struct literal or type describing the captures to make available to the block,
as well as the type of a function whose return value and params will become the return value and params of the block's inner `invoke` function. `Block` is a comptime function which returns a type. `initBlock` takes in a type created with `Block`, a struct literal whose fields will be assigned to the block's captures, and a function which will become the block's `invoke` function and returns a heap-allocated block. (the Objective-C runtime will call `free` on it when it's done, so one needs to create this block with `malloc`.) typically one wants to let Objective-C call into this block itself, but a `invokeBlock` function is provided if that's not the case.

the repo linked above contains examples of all of this in use. would be very happy for any feedback you have, even if you're not interested in adding this functionality!