### PR TITLE
Supports retain/release for Object.

### DIFF
--- a/src/object.zig
+++ b/src/object.zig
@@ -97,15 +97,10 @@ pub const Object = struct {
         c.object_setIvar(self.value, ivar, val.value);
     }
 
-    /// In MacOS SDK, the memory is managed by ARC(Automatic Reference Counting).
-    /// Therefore, it not must retain an object explictlly.
-    /// But if you'd like to keep reference of objc object in ziglang-side, it could use this method to avoid releqsing object by ARC.
     pub fn retain(self: Object) Object {
         return fromId(objc_retain(self.value));
     }
 
-    /// if you have use the retain method, you must call the release method.
-    /// Otherwise, a memory leak will occur.
     pub fn release(self: Object) void {
         objc_release(self.value);
     }
@@ -113,6 +108,10 @@ pub const Object = struct {
 
 extern "c" fn objc_retain(objc.c.id) objc.c.id;
 extern "c" fn objc_release(objc.c.id) void;
+
+fn retainCount(obj: Object) c_ulong {
+    return obj.msgSend(c_ulong, objc.Sel.registerName("retainCount"), .{});
+}
 
 test {
     const testing = std.testing;
@@ -123,10 +122,6 @@ test {
     try testing.expect(obj.value != null);
     try testing.expectEqualStrings("NSObject", obj.getClassName());
     obj.msgSend(void, objc.sel("dealloc"), .{});
-}
-
-fn retainCount(obj: Object) c_ulong {
-    return obj.msgSend(c_ulong, objc.Sel.registerName("retainCount"), .{});
 }
 
 test "retain object" {

--- a/src/object.zig
+++ b/src/object.zig
@@ -97,10 +97,15 @@ pub const Object = struct {
         c.object_setIvar(self.value, ivar, val.value);
     }
 
+    /// In MacOS SDK, the memory is managed by ARC(Automatic Reference Counting).
+    /// Therefore, it not must retain an object explictlly.
+    /// But if you'd like to keep reference of objc object in ziglang-side, it could use this method to avoid releqsing object by ARC.
     pub fn retain(self: Object) Object {
         return fromId(objc_retain(self.value));
     }
 
+    /// if you have use the retain method, you must call the release method.
+    /// Otherwise, a memory leak will occur.
     pub fn release(self: Object) void {
         objc_release(self.value);
     }

--- a/src/object.zig
+++ b/src/object.zig
@@ -96,7 +96,18 @@ pub const Object = struct {
         const ivar = c.object_getInstanceVariable(self.value, name, null);
         c.object_setIvar(self.value, ivar, val.value);
     }
+
+    pub fn retain(self: Object) Object {
+        return fromId(objc_retain(self.value));
+    }
+
+    pub fn release(self: Object) void {
+        objc_release(self.value);
+    }
 };
+
+extern "c" fn objc_retain(objc.c.id) objc.c.id;
+extern "c" fn objc_release(objc.c.id) void;
 
 test {
     const testing = std.testing;
@@ -106,5 +117,26 @@ test {
     const obj = NSObject.msgSend(objc.Object, objc.Sel.registerName("alloc"), .{});
     try testing.expect(obj.value != null);
     try testing.expectEqualStrings("NSObject", obj.getClassName());
+    obj.msgSend(void, objc.sel("dealloc"), .{});
+}
+
+fn retainCount(obj: Object) c_ulong {
+    return obj.msgSend(c_ulong, objc.Sel.registerName("retainCount"), .{});
+}
+
+test "retain object" {
+    const testing = std.testing;
+    const NSObject = objc.getClass("NSObject").?;
+
+    const obj = NSObject.msgSend(objc.Object, objc.Sel.registerName("alloc"), .{});
+    _ = obj.msgSend(objc.Object, objc.Sel.registerName("init"), .{});
+    try testing.expectEqual(@as(c_ulong, 1), retainCount(obj));
+
+    _ = obj.retain();
+    try testing.expectEqual(@as(c_ulong, 2), retainCount(obj));
+
+    obj.release();
+    try testing.expectEqual(@as(c_ulong, 1), retainCount(obj));
+
     obj.msgSend(void, objc.sel("dealloc"), .{});
 }


### PR DESCRIPTION
In MacOS SDK, the memory is managed by ARC(Automatic Reference Counting).
Therefore, it not must retain an object explictlly.
But if you'd like to keep reference of objc object in ziglang-side, it could use this method to avoid releqsing object by ARC.

For instance,

* keep AppKit widget reference for latter access.
* cache CALayer path.
* etc,...

