### PR TITLE
Build.zig tweaks, zig breakage fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,11 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const add_paths = b.option(bool, "add-paths", "add macos SDK paths from dependency") orelse false;
 
-    const objc = b.addModule("objc", .{ .root_source_file = .{ .path = "src/main.zig" } });
+    const objc = b.addModule("objc", .{
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
     if (add_paths) @import("macos_sdk").addPathsModule(objc);
     objc.linkSystemLibrary("objc", .{});
     objc.linkFramework("Foundation", .{});

--- a/build.zig
+++ b/build.zig
@@ -3,8 +3,12 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
+    const add_paths = b.option(bool, "add-paths", "add macos SDK paths from dependency") orelse false;
 
-    _ = b.addModule("objc", .{ .root_source_file = .{ .path = "src/main.zig" } });
+    const objc = b.addModule("objc", .{ .root_source_file = .{ .path = "src/main.zig" } });
+    if (add_paths) @import("macos_sdk").addPathsModule(objc);
+    objc.linkSystemLibrary("objc", .{});
+    objc.linkFramework("Foundation", .{});
 
     const tests = b.addTest(.{
         .name = "objc-test",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,8 +10,8 @@
     },
     .dependencies = .{
         .macos_sdk = .{
-            .url = "https://github.com/mitchellh/zig-build-macos-sdk/archive/4186e9fd445d12041651abe59ea5f396499b0844.tar.gz",
-            .hash = "1220bc2612b57b0cfaaecbcac38e3144e5a9362ff668d71eb8334e895047bdbb7148",
+            .url = "https://github.com/mitchellh/zig-build-macos-sdk/archive/ee70f27c08680307fa35ada92e6b2c36e0ff84c6.tar.gz",
+            .hash = "1220b415f529f1c04ed876c2b481e9f8119d353d4e3d4d7c8607ee302d2142e13eca",
         },
     },
 }

--- a/flake.lock
+++ b/flake.lock
@@ -109,11 +109,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1711585351,
-        "narHash": "sha256-rVJ/lRPQNCjU/98SZmQUhksoZOrKajwGS1UmEMuXzss=",
+        "lastModified": 1712923708,
+        "narHash": "sha256-gx0nOU67FBJ6S4S2VtnahhSHW9CW8zsYzE616/NV4eo=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "6ac62029cf9a5fd2cec831a2dfc541f3cae63297",
+        "rev": "c4412eedbfed081eefd5120c85e7910a953ae818",
         "type": "github"
       },
       "original": {

--- a/src/block.zig
+++ b/src/block.zig
@@ -41,7 +41,7 @@ pub fn Block(
             .size = @sizeOf(Context),
             .copy_helper = &descCopyHelper,
             .dispose_helper = &descDisposeHelper,
-            .signature = objc.comptimeEncode(InvokeFn).ptr,
+            .signature = &objc.comptimeEncode(InvokeFn),
         };
 
         /// This is the function type that is called back.

--- a/src/class.zig
+++ b/src/class.zig
@@ -76,7 +76,7 @@ pub const Class = struct {
             self.value,
             objc.sel(name).value,
             @ptrCast(&imp),
-            encoding.ptr,
+            &encoding,
         ));
     }
 


### PR DESCRIPTION
this is maybe two PRs rather than one... happy to PR separately if you'd prefer.

1. added a `-Dadd-paths` option that users downstream of this package can use to optionally add the macOS SDK paths to the module. also added `linkSystemLibrary` calls to `build.zig` now that Zig supports them for modules.
2. I noticed that we had compile errors on the latest Zig having to do with pointers to comptime variable memory. I resolved this by changing the semantics of `comptimeEncode`: it now returns an array rather than a slice.