### PR TITLE
make compatible with 0.14.0-dev.1951 (not backwards compatible)

### DIFF
--- a/src/block.zig
+++ b/src/block.zig
@@ -127,16 +127,6 @@ pub fn Block(
                     .params = &params,
                 },
             });
-
-            // return @Type(.{
-            //     .fn = .{
-            //         .calling_convention = .C,
-            //         .is_generic = false,
-            //         .is_var_args = false,
-            //         .return_type = Return,
-            //         .params = &params,
-            //     },
-            // });
         }
     };
 }

--- a/src/block.zig
+++ b/src/block.zig
@@ -34,7 +34,7 @@ pub fn Block(
 ) type {
     return struct {
         const Self = @This();
-        const captures_info = @typeInfo(Captures).Struct;
+        const captures_info = @typeInfo(Captures).@"struct";
         const InvokeFn = FnType(anyopaque);
         const descriptor: Descriptor = .{
             .reserved = 0,
@@ -63,7 +63,7 @@ pub fn Block(
             var ctx = try alloc.create(Context);
             errdefer alloc.destroy(ctx);
 
-            const flags: BlockFlags = .{ .stret = @typeInfo(Return) == .Struct };
+            const flags: BlockFlags = .{ .stret = @typeInfo(Return) == .@"struct" };
             ctx.isa = NSConcreteStackBlock;
             ctx.flags = @bitCast(flags);
             ctx.invoke = @ptrCast(func);
@@ -118,9 +118,8 @@ pub fn Block(
             for (Args, 1..) |Arg, i| {
                 params[i] = .{ .is_generic = false, .is_noalias = false, .type = Arg };
             }
-
             return @Type(.{
-                .Fn = .{
+                .@"fn" = .{
                     .calling_convention = .C,
                     .is_generic = false,
                     .is_var_args = false,
@@ -128,6 +127,16 @@ pub fn Block(
                     .params = &params,
                 },
             });
+
+            // return @Type(.{
+            //     .fn = .{
+            //         .calling_convention = .C,
+            //         .is_generic = false,
+            //         .is_var_args = false,
+            //         .return_type = Return,
+            //         .params = &params,
+            //     },
+            // });
         }
     };
 }
@@ -135,7 +144,7 @@ pub fn Block(
 /// This is the type of a block structure that is passed as the first
 /// argument to any block invocation. See Block.
 fn BlockContext(comptime Captures: type, comptime InvokeFn: type) type {
-    const captures_info = @typeInfo(Captures).Struct;
+    const captures_info = @typeInfo(Captures).@"struct";
     var fields: [captures_info.fields.len + 5]std.builtin.Type.StructField = undefined;
     fields[0] = .{
         .name = "isa",
@@ -163,7 +172,7 @@ fn BlockContext(comptime Captures: type, comptime InvokeFn: type) type {
         .type = *const InvokeFn,
         .default_value = null,
         .is_comptime = false,
-        .alignment = @typeInfo(*const InvokeFn).Pointer.alignment,
+        .alignment = @typeInfo(*const InvokeFn).pointer.alignment,
     };
     fields[4] = .{
         .name = "descriptor",
@@ -190,7 +199,7 @@ fn BlockContext(comptime Captures: type, comptime InvokeFn: type) type {
     }
 
     return @Type(.{
-        .Struct = .{
+        .@"struct" = .{
             .layout = .@"extern",
             .fields = &fields,
             .decls = &.{},

--- a/src/c.zig
+++ b/src/c.zig
@@ -6,7 +6,7 @@ pub usingnamespace @cImport({
 /// This is a funky helper to help with the fact that some macOS
 /// SDKs have an i8 return value for bools and some have stdbool.
 pub fn boolResult(comptime Fn: type, result: anytype) bool {
-    const fn_info = @typeInfo(Fn).Fn;
+    const fn_info = @typeInfo(Fn).@"fn";
     return switch (fn_info.return_type.?) {
         bool => result,
         i8 => result == 1,

--- a/src/class.zig
+++ b/src/class.zig
@@ -51,7 +51,7 @@ pub const Class = struct {
     // imp should be a function with C calling convention
     // whose first two arguments are a `c.id` and a `c.SEL`.
     pub fn replaceMethod(self: Class, name: [:0]const u8, imp: anytype) void {
-        const fn_info = @typeInfo(@TypeOf(imp)).Fn;
+        const fn_info = @typeInfo(@TypeOf(imp)).@"fn";
         assert(fn_info.calling_convention == .C);
         assert(fn_info.is_var_args == false);
         assert(fn_info.params.len >= 2);
@@ -65,7 +65,7 @@ pub const Class = struct {
     // whose first two arguments are a `c.id` and a `c.SEL`.
     pub fn addMethod(self: Class, name: [:0]const u8, imp: anytype) !bool {
         const Fn = @TypeOf(imp);
-        const fn_info = @typeInfo(Fn).Fn;
+        const fn_info = @typeInfo(Fn).@"fn";
         assert(fn_info.calling_convention == .C);
         assert(fn_info.is_var_args == false);
         assert(fn_info.params.len >= 2);
@@ -202,7 +202,7 @@ test "addMethod" {
         const My_Class = allocateClassPair(objc.getClass("NSObject").?, "my_class").?;
         defer registerClassPair(My_Class);
         std.debug.assert(try My_Class.addMethod("my_addition", struct {
-            fn imp(target: objc.c.id, sel: objc.c.SEL, a: i32, b: i32) callconv(.C) i32 {
+            fn imp(target: c.id, sel: c.SEL, a: i32, b: i32) callconv(.C) i32 {
                 _ = sel;
                 _ = target;
                 return a + b;

--- a/src/encoding.zig
+++ b/src/encoding.zig
@@ -83,14 +83,14 @@ pub const Encoding = union(enum) {
             c.Class, objc.Class => .class,
             c.id, objc.Object => .object,
             else => switch (@typeInfo(T)) {
-                .Array => |arr| .{ .array = .{ .len = arr.len, .arr_type = arr.child } },
-                .Struct => .{ .structure = .{ .struct_type = T, .show_type_spec = true } },
-                .Union => .{ .@"union" = .{
+                .array => |arr| .{ .array = .{ .len = arr.len, .arr_type = arr.child } },
+                .@"struct" => .{ .structure = .{ .struct_type = T, .show_type_spec = true } },
+                .@"union" => .{ .@"union" = .{
                     .union_type = T,
                     .show_type_spec = true,
                 } },
-                .Pointer => |ptr| .{ .pointer = .{ .ptr_type = T, .size = ptr.size } },
-                .Fn => |fn_info| .{ .function = fn_info },
+                .pointer => |ptr| .{ .pointer = .{ .ptr_type = T, .size = ptr.size } },
+                .@"fn" => |fn_info| .{ .function = fn_info },
                 else => @compileError("unsupported type: " ++ @typeName(T)),
             },
         };
@@ -129,7 +129,7 @@ pub const Encoding = union(enum) {
             },
             .structure => |s| {
                 const struct_info = @typeInfo(s.struct_type);
-                assert(struct_info.Struct.layout == .@"extern");
+                assert(struct_info.@"struct".layout == .@"extern");
 
                 // Strips the fully qualified type name to leave just the
                 // type name. Used in naming the Struct in an encoding.
@@ -141,7 +141,7 @@ pub const Encoding = union(enum) {
                 // of the struct (determined by levels of pointer indirection)
                 if (s.show_type_spec) {
                     try writer.writeAll("=");
-                    inline for (struct_info.Struct.fields) |field| {
+                    inline for (struct_info.@"struct".fields) |field| {
                         const field_encode = init(field.type);
                         try field_encode.format(fmt, options, writer);
                     }
@@ -151,7 +151,7 @@ pub const Encoding = union(enum) {
             },
             .@"union" => |u| {
                 const union_info = @typeInfo(u.union_type);
-                assert(union_info.Union.layout == .@"extern");
+                assert(union_info.@"union".layout == .@"extern");
 
                 // Strips the fully qualified type name to leave just the
                 // type name. Used in naming the Union in an encoding
@@ -163,7 +163,7 @@ pub const Encoding = union(enum) {
                 // of the Union (determined by levels of pointer indirection)
                 if (u.show_type_spec) {
                     try writer.writeAll("=");
-                    inline for (union_info.Union.fields) |field| {
+                    inline for (union_info.@"union".fields) |field| {
                         const field_encode = init(field.type);
                         try field_encode.format(fmt, options, writer);
                     }
@@ -230,8 +230,8 @@ fn indirectionCountAndType(comptime T: type) struct {
 } {
     var WalkType = T;
     var count: usize = 0;
-    while (@typeInfo(WalkType) == .Pointer) : (count += 1) {
-        WalkType = @typeInfo(WalkType).Pointer.child;
+    while (@typeInfo(WalkType) == .pointer) : (count += 1) {
+        WalkType = @typeInfo(WalkType).pointer.child;
     }
 
     return .{ .child = WalkType, .indirection_levels = count };

--- a/src/msg_send.zig
+++ b/src/msg_send.zig
@@ -91,15 +91,15 @@ pub fn MsgSend(comptime T: type) type {
                 // x86_64 depends on the return type...
                 .x86_64 => switch (@typeInfo(Return)) {
                     // Most types use objc_msgSend
-                    inline .Int,
-                    .Bool,
-                    .Enum,
-                    .Pointer,
-                    .Void,
+                    inline .int,
+                    .bool,
+                    .@"enum",
+                    .pointer,
+                    .void,
                     => if (super) &c.objc_msgSendSuper else &c.objc_msgSend,
 
-                    .Optional => |opt| opt: {
-                        assert(@typeInfo(opt.child) == .Pointer);
+                    .optional => |opt| opt: {
+                        assert(@typeInfo(opt.child) == .pointer);
                         break :opt if (super) &c.objc_msgSendSuper else &c.objc_msgSend;
                     },
 
@@ -110,7 +110,7 @@ pub fn MsgSend(comptime T: type) type {
                     // know what the breakpoint actually is for that. This SO
                     // answer says 16 bytes so I'm going to use that but I have
                     // no idea...
-                    .Struct => blk: {
+                    .@"struct" => blk: {
                         if (@sizeOf(Return) > 16) {
                             break :blk if (super)
                                 &c.objc_msgSendSuper_stret
@@ -129,7 +129,7 @@ pub fn MsgSend(comptime T: type) type {
                     // more complex rules but we don't support i386 at the time
                     // of this comment and probably never will since all i386
                     // Apple models are discontinued at this point.
-                    .Float => |float| switch (float.bits) {
+                    .float => |float| switch (float.bits) {
                         64 => if (super) &c.objc_msgSendSuper_fpret else &c.objc_msgSend_fpret,
                         else => if (super) &c.objc_msgSendSuper else &c.objc_msgSend,
                     },
@@ -176,7 +176,7 @@ fn MsgSendFn(
     comptime Target: type,
     comptime Args: type,
 ) type {
-    const argsInfo = @typeInfo(Args).Struct;
+    const argsInfo = @typeInfo(Args).@"struct";
     assert(argsInfo.is_tuple);
 
     // Target must always be an "id". Lots of types (Class, Object, etc.)
@@ -205,7 +205,7 @@ fn MsgSendFn(
     };
 
     return @Type(.{
-        .Fn = .{
+        .@"fn" = .{
             .calling_convention = .C,
             .is_generic = false,
             .is_var_args = false,

--- a/src/object.zig
+++ b/src/object.zig
@@ -106,8 +106,8 @@ pub const Object = struct {
     }
 };
 
-extern "c" fn objc_retain(objc.c.id) objc.c.id;
-extern "c" fn objc_release(objc.c.id) void;
+extern "c" fn objc_retain(c.id) c.id;
+extern "c" fn objc_release(c.id) void;
 
 fn retainCount(obj: Object) c_ulong {
     return obj.msgSend(c_ulong, objc.Sel.registerName("retainCount"), .{});


### PR DESCRIPTION
At some commit since 0.13 all off the `Type` tagged union keys were lowercased. This PR updates all the references to those keys. 

There was also a new build error due to `objc.c` ambiguous reference which I fixed.

This is not backwards compatible at all - open to ideas of how to handle this. 

Totally understand if you want to wait for 0.14.0 to merge this but just wanted to put it up if its useful for others.