### PR TITLE
iterator: support iteration using `NSFastEnumeration`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.direnv/
 .zig-cache
 zig-out

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ pub fn build(b: *std.build.Builder) !void {
 }
 ```
 
+Note that `zig-objc` will find and link to headers from the target SDK
+(macOS, iOS, etc.) automatically by finding your Xcode installation. If
+Xcode is not installed, you can add it manually but you must set the
+`-Dadd-paths=false` flag.
+
 **`zig-objc` only works with released versions of Zig.** We don't support
 nightly versions because the Zig compiler is still changing too much.
 

--- a/src/iterator.zig
+++ b/src/iterator.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const objc = @import("main.zig");
+
+// From <Foundation/NSEnumerator.h>.
+const NSFastEnumerationState = extern struct {
+    state: c_ulong,
+    itemsPtr: ?[*]objc.c.id,
+    mutationsPtr: ?*c_ulong,
+    extra: [5]c_ulong,
+};
+
+pub const Iterator = struct {
+    object: objc.Object,
+    sel: objc.Sel,
+    state: NSFastEnumerationState,
+    initial_mutations_value: ?c_ulong,
+    // Clang compiles `for…in` loops with a size 16 buffer.
+    buffer: [16]objc.c.id,
+    slice: []objc.c.id,
+
+    pub fn init(object: objc.Object) Iterator {
+        return .{
+            .object = object,
+            .sel = objc.sel("countByEnumeratingWithState:objects:count:"),
+            .state = .{
+                .state = 0,
+                .itemsPtr = null,
+                .mutationsPtr = null,
+                .extra = [_]c_ulong{0} ** 5,
+            },
+            .initial_mutations_value = null,
+            .buffer = [_]objc.c.id{null} ** 16,
+            .slice = &[_]objc.c.id{},
+        };
+    }
+
+    pub fn next(self: *Iterator) ?objc.Object {
+        if (self.slice.len == 0) {
+            // Ask for some more objects.
+            const count = self.object.msgSend(c_ulong, self.sel, .{
+                &self.state,
+                &self.buffer,
+                self.buffer.len,
+            });
+            if (self.initial_mutations_value) |value| {
+                // Call the mutation handler if the mutations value has
+                // changed since the start of iteration.
+                if (value != self.state.mutationsPtr.?.*) {
+                    objc.c.objc_enumerationMutation(self.object.value);
+                }
+            } else {
+                self.initial_mutations_value = self.state.mutationsPtr.?.*;
+            }
+            self.slice = self.state.itemsPtr.?[0..count];
+        }
+
+        if (self.slice.len > 0) {
+            const first = self.slice[0];
+            self.slice = self.slice[1..];
+            return objc.Object.fromId(first);
+        } else {
+            return null;
+        }
+    }
+};
+
+test "NSArray iteration" {
+    const testing = std.testing;
+    const NSArray = objc.getClass("NSMutableArray").?;
+    const NSNumber = objc.getClass("NSNumber").?;
+    const array = NSArray.msgSend(
+        objc.Object,
+        "arrayWithCapacity:",
+        .{@as(c_ulong, 10)},
+    );
+    defer array.release();
+    for (0..@as(c_int, 10)) |i| {
+        const i_number = NSNumber.msgSend(objc.Object, "numberWithInt:", .{i});
+        defer i_number.release();
+        array.msgSend(void, "addObject:", .{i_number});
+    }
+    var result: c_int = 0;
+    var iter = array.iterate();
+    while (iter.next()) |elem| {
+        result = (result * 10) + elem.getProperty(c_int, "intValue");
+    }
+    try testing.expectEqual(123456789, result);
+}
+
+test "NSDictionary iteration" {
+    const testing = std.testing;
+    const NSMutableDictionary = objc.getClass("NSMutableDictionary").?;
+    const NSNumber = objc.getClass("NSNumber").?;
+    const dict = NSMutableDictionary.msgSend(
+        objc.Object,
+        "dictionaryWithCapacity:",
+        .{@as(c_ulong, 100)},
+    );
+    defer dict.release();
+    for (0..@as(c_int, 100)) |i| {
+        const i_number = NSNumber.msgSend(objc.Object, "numberWithInt:", .{i});
+        defer i_number.release();
+        dict.msgSend(void, "setValue:forKey:", .{
+            i_number,
+            i_number.getProperty(objc.Object, "stringValue"),
+        });
+    }
+    var result: c_int = 0;
+    var iter = dict.iterate();
+    while (iter.next()) |key| {
+        const value = dict.msgSend(objc.Object, "valueForKey:", .{key});
+        result += value.getProperty(c_int, "intValue");
+    }
+    try testing.expectEqual(4950, result);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,7 @@ pub usingnamespace @import("autorelease.zig");
 pub usingnamespace @import("block.zig");
 pub usingnamespace @import("class.zig");
 pub usingnamespace @import("encoding.zig");
+pub usingnamespace @import("iterator.zig");
 pub usingnamespace @import("object.zig");
 pub usingnamespace @import("property.zig");
 pub usingnamespace @import("protocol.zig");

--- a/src/object.zig
+++ b/src/object.zig
@@ -106,6 +106,8 @@ pub const Object = struct {
         objc_release(self.value);
     }
 
+    /// Return an iterator for this object. The object must implement the
+    /// `NSFastEnumeration` protocol.
     pub fn iterate(self: Object) Iterator {
         return Iterator.init(self);
     }

--- a/src/object.zig
+++ b/src/object.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const c = @import("c.zig");
 const objc = @import("main.zig");
 const MsgSend = @import("msg_send.zig").MsgSend;
+const Iterator = @import("iterator.zig").Iterator;
 
 /// Object is an instance of a class.
 pub const Object = struct {
@@ -103,6 +104,10 @@ pub const Object = struct {
 
     pub fn release(self: Object) void {
         objc_release(self.value);
+    }
+
+    pub fn iterate(self: Object) Iterator {
+        return Iterator.init(self);
     }
 };
 


### PR DESCRIPTION
Implement the consumer side of the `NSFastEnumeration` protocol, matching the compilation scheme used by Clang for Objective‐C `for…in` loops.

I’ve never written Zig before, and I don’t know much about Objective‐C either, so I’m sure there are a lot of nits to pick here. I tried my best to get the Objective‐C memory management right, but manual memory management is hard. I elected not to explicitly check whether the object conforms to `NSFastEnumeration` – Clang does that at compile time – so there’ll instead just be an unrecoverable runtime error if you misuse the API. Happy to hear feedback on code style and that design point.