### PR TITLE
take pointers rather than slices

### DIFF
--- a/src/object.zig
+++ b/src/object.zig
@@ -34,7 +34,7 @@ pub const Object = struct {
     /// Set a property. This is a helper around getProperty and is
     /// strictly less performant than doing it manually. Consider doing
     /// this manually if performance is critical.
-    pub fn setProperty(self: Object, comptime n: [:0]const u8, v: anytype) void {
+    pub fn setProperty(self: Object, comptime n: [*:0]const u8, v: anytype) void {
         const Class = self.getClass().?;
         const setter = setter: {
             // See getProperty for why we do this.
@@ -59,7 +59,7 @@ pub const Object = struct {
     /// Get a property. This is a helper around Class.getProperty and is
     /// strictly less performant than doing it manually. Consider doing
     /// this manually if performance is critical.
-    pub fn getProperty(self: Object, comptime T: type, comptime n: [:0]const u8) T {
+    pub fn getProperty(self: Object, comptime T: type, comptime n: [*:0]const u8) T {
         const Class = self.getClass().?;
         const getter = getter: {
             // Sometimes a property is not a property because it has been
@@ -91,12 +91,12 @@ pub const Object = struct {
         return c.object_isClass(self.value) == 1;
     }
 
-    pub fn getInstanceVariable(self: Object, name: [:0]const u8) Object {
+    pub fn getInstanceVariable(self: Object, name: [*:0]const u8) Object {
         const ivar = c.object_getInstanceVariable(self.value, name, null);
         return fromId(c.object_getIvar(self.value, ivar));
     }
 
-    pub fn setInstanceVariable(self: Object, name: [:0]const u8, val: Object) void {
+    pub fn setInstanceVariable(self: Object, name: [*:0]const u8, val: Object) void {
         const ivar = c.object_getInstanceVariable(self.value, name, null);
         c.object_setIvar(self.value, ivar, val.value);
     }

--- a/src/property.zig
+++ b/src/property.zig
@@ -11,9 +11,9 @@ pub const Property = extern struct {
     }
 
     /// Returns the value of a property attribute given the attribute name.
-    pub fn copyAttributeValue(self: Property, attr: [:0]const u8) ?[:0]u8 {
+    pub fn copyAttributeValue(self: Property, attr: [*:0]const u8) ?[:0]u8 {
         return std.mem.sliceTo(
-            c.property_copyAttributeValue(self.value, attr.ptr) orelse return null,
+            c.property_copyAttributeValue(self.value, attr) orelse return null,
             0,
         );
     }

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -19,7 +19,7 @@ pub const Protocol = extern struct {
 
     pub fn getProperty(
         self: Protocol,
-        name: [:0]const u8,
+        name: [*:0]const u8,
         is_required: bool,
         is_instance: bool,
     ) ?objc.Property {
@@ -39,6 +39,6 @@ pub const Protocol = extern struct {
     }
 };
 
-pub fn getProtocol(name: [:0]const u8) ?Protocol {
+pub fn getProtocol(name: [*:0]const u8) ?Protocol {
     return .{ .value = c.objc_getProtocol(name) orelse return null };
 }

--- a/src/sel.zig
+++ b/src/sel.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const c = @import("c.zig").c;
 
 // Shorthand, equivalent to Sel.registerName
-pub inline fn sel(name: [:0]const u8) Sel {
+pub inline fn sel(name: [*:0]const u8) Sel {
     return Sel.registerName(name);
 }
 
@@ -11,9 +11,9 @@ pub const Sel = struct {
 
     /// Registers a method with the Objective-C runtime system, maps the
     /// method name to a selector, and returns the selector value.
-    pub fn registerName(name: [:0]const u8) Sel {
+    pub fn registerName(name: [*:0]const u8) Sel {
         return Sel{
-            .value = c.sel_registerName(name.ptr),
+            .value = c.sel_registerName(name),
         };
     }
 


### PR DESCRIPTION
Modified some of the wrapper functions to take sentinel-terminated pointers rather than slices.  Allows me to remove some unnecessary `sliceTo` calls in certain cases in my code as the underlying API being wrapped only requires the pointer.