### PR TITLE
Fix runtime panic for tagged pointers

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,6 +26,7 @@ pub fn build(b: *std.Build) !void {
     });
     tests.linkSystemLibrary("objc");
     tests.linkFramework("Foundation");
+    tests.linkFramework("AppKit"); // Required by 'tagged pointer' test.
     try addAppleSDK(b, tests.root_module);
     b.installArtifact(tests);
 

--- a/src/object.zig
+++ b/src/object.zig
@@ -164,3 +164,55 @@ test "retain object" {
 
     obj.msgSend(void, objc.sel("dealloc"), .{});
 }
+
+test "tagged pointer" {
+    const testing = std.testing;
+
+    // We can't force Objective-C to provide us with an unaligned tagged
+    // pointer, so we try several times using different classes. We use
+    // different classes instead of values, since pointers from the same
+    // class will have the same alignment during a single execution (aarch64).
+    const obj = blk: {
+        var Class = objc.getClass("NSNumber").?;
+        var sel = objc.Sel.registerName("numberWithChar:");
+        var obj = Class.msgSend(objc.Object, sel, .{@as(u8, @intCast(5))});
+
+        // We're only interested in an unaligned pointer.
+        if (!std.mem.isAligned(@intFromPtr(obj.value), @alignOf(usize))) break :blk obj;
+
+        Class = objc.getClass("NSString").?;
+        sel = objc.Sel.registerName("stringWithUTF8String:");
+        obj = Class.msgSend(objc.Object, sel, .{"foo"});
+        if (!std.mem.isAligned(@intFromPtr(obj.value), @alignOf(usize))) break :blk obj;
+
+        Class = objc.getClass("NSDate").?;
+        sel = objc.Sel.registerName("date");
+        obj = Class.msgSend(objc.Object, sel, .{});
+        if (!std.mem.isAligned(@intFromPtr(obj.value), @alignOf(usize))) break :blk obj;
+
+        const colors = [_][:0]const u8{
+            "clearColor",    "blackColor",  "blueColor",  "brownColor",     "cyanColor",
+            "darkGrayColor", "grayColor",   "greenColor", "lightGrayColor", "magentaColor",
+            "orangeColor",   "purpleColor", "redColor",   "whiteColor",     "yellowColor",
+        };
+
+        Class = objc.getClass("NSColor").?;
+        for (colors) |color| {
+            sel = objc.Sel.registerName(color);
+            obj = Class.msgSend(objc.Object, sel, .{});
+            if (!std.mem.isAligned(@intFromPtr(obj.value), @alignOf(usize))) break :blk obj;
+        }
+
+        // In the unlikely event that we don't find an unaligned tagged pointer.
+        std.log.warn("skipped 'tagged pointer' test because we couldn't find an unaligned tagged pointer", .{});
+        return error.SkipZigTest;
+    };
+
+    // A tagged object is not allocated on the heap and cannot be retained.
+    try testing.expect(retainCount(obj) != 1);
+
+    // `Object.fromId` must work even when the pointer is unaligned.
+    const obj_ptr = @intFromPtr(obj.value);
+    try testing.expect(!std.mem.isAligned(obj_ptr, @alignOf(usize)));
+    try testing.expect(std.meta.eql(obj, Object.fromId(obj.value)));
+}


### PR DESCRIPTION
This fix adds support for [**tagged pointers**](https://alwaysprocessing.blog/2023/03/19/objc-tagged-ptr), an internal optimization used by the Objective-C runtime for small objects like short `NSStrings` and `NSNumbers`. These “pointers” may not be aligned, as they encode data directly within the pointer value itself.

To support tagged pointers safely, the code now explicitly disables Zig’s runtime alignment safety checks when casting such values. This avoids runtime panics caused by misaligned pointer dereferencing.

The issue was observed when interacting with an Objective-C API that returned a `NSString`, which turned out to be a tagged pointer (and not a real heap pointer). The previous implementation assumed proper alignment and thus crashed during a cast operation safety check.