### PR TITLE
Remove error union from `Class.addMethod` return type

### DIFF
--- a/src/class.zig
+++ b/src/class.zig
@@ -66,10 +66,10 @@ pub const Class = struct {
         _ = c.class_replaceMethod(self.value, objc.sel(name).value, @ptrCast(&imp), null);
     }
 
-    /// allows adding new methods; returns true on success.
+    // allows adding new methods; returns true on success.
     // imp should be a function with C calling convention
     // whose first two arguments are a `c.id` and a `c.SEL`.
-    pub fn addMethod(self: Class, name: [:0]const u8, imp: anytype) !bool {
+    pub fn addMethod(self: Class, name: [:0]const u8, imp: anytype) bool {
         const Fn = @TypeOf(imp);
         const fn_info = @typeInfo(Fn).@"fn";
         assert(std.meta.eql(fn_info.calling_convention, std.builtin.CallingConvention.c));
@@ -207,7 +207,7 @@ test "addMethod" {
     const My_Class = setup: {
         const My_Class = allocateClassPair(objc.getClass("NSObject").?, "my_class").?;
         defer registerClassPair(My_Class);
-        std.debug.assert(try My_Class.addMethod("my_addition", struct {
+        std.debug.assert(My_Class.addMethod("my_addition", struct {
             fn imp(target: objc.c.id, sel: objc.c.SEL, a: i32, b: i32) callconv(.C) i32 {
                 _ = sel;
                 _ = target;


### PR DESCRIPTION
The `addMethod()` function does not return any error.
This is a **breaking change** to the API, but I believe it’s worth it for the sake of both correctness and consistency with `addIvar()`.