### PR TITLE
Fix `msgSendSuper` regression.

### DIFF
--- a/src/msg_send.zig
+++ b/src/msg_send.zig
@@ -65,7 +65,7 @@ pub fn MsgSend(comptime T: type) type {
             const msg_send_ptr: *const Fn = @ptrCast(msg_send_fn);
             var super: c.objc_super = .{
                 .receiver = target.value,
-                .class = superclass.value,
+                .super_class = superclass.value,
             };
             const result = @call(.auto, msg_send_ptr, .{ &super, sel.value } ++ args);
 


### PR DESCRIPTION
Regressed in the Zig 0.15 upgrade.

Not sure how the [mentioned test](https://github.com/mitchellh/zig-objc/pull/27#issuecomment-3352405326) passed, can it be specific for macOS 26?
On my machine (macOS 15), calling `msgSendSuper` fails to compile without this fix.
