### PR TITLE
Fix compilation on Zig 0.16

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,9 +26,9 @@ pub fn build(b: *std.Build) !void {
             .optimize = optimize,
         }),
     });
-    tests.linkSystemLibrary("objc");
-    tests.linkFramework("Foundation");
-    tests.linkFramework("AppKit"); // Required by 'tagged pointer' test.
+    tests.root_module.linkSystemLibrary("objc", .{});
+    tests.root_module.linkFramework("Foundation", .{});
+    tests.root_module.linkFramework("AppKit", .{}); // Required by 'tagged pointer' test.
     try addAppleSDK(b, tests.root_module);
     b.installArtifact(tests);
 
@@ -68,6 +68,7 @@ pub fn addAppleSDK(b: *std.Build, m: *std.Build.Module) !void {
     if (!gop.found_existing) {
         gop.value_ptr.* = std.zig.system.darwin.getSdk(
             b.allocator,
+            b.graph.io,
             &m.resolved_target.?.result,
         );
     }

--- a/src/object.zig
+++ b/src/object.zig
@@ -44,7 +44,9 @@ pub const Object = struct {
 
     /// Returns the class name of a given object.
     pub fn getClassName(self: Object) [:0]const u8 {
-        return std.mem.sliceTo(c.object_getClassName(self.value), 0);
+        const ptr = c.object_getClassName(self.value);
+        const len = std.mem.indexOfSentinel(u8, 0, ptr);
+        return ptr[0..len :0];
     }
 
     /// Set a property. This is a helper around getProperty and is

--- a/src/property.zig
+++ b/src/property.zig
@@ -7,15 +7,16 @@ pub const Property = extern struct {
 
     /// Returns the name of a property.
     pub fn getName(self: Property) [:0]const u8 {
-        return std.mem.sliceTo(c.property_getName(self.value), 0);
+        const ptr = c.property_getName(self.value);
+        const len = std.mem.indexOfSentinel(u8, 0, ptr);
+        return ptr[0..len :0];
     }
 
     /// Returns the value of a property attribute given the attribute name.
     pub fn copyAttributeValue(self: Property, attr: [:0]const u8) ?[:0]u8 {
-        return std.mem.sliceTo(
-            c.property_copyAttributeValue(self.value, attr.ptr) orelse return null,
-            0,
-        );
+        const ptr = c.property_copyAttributeValue(self.value, attr.ptr) orelse return null;
+        const len = std.mem.indexOfSentinel(u8, 0, ptr);
+        return ptr[0..len :0];
     }
 
     comptime {

--- a/src/protocol.zig
+++ b/src/protocol.zig
@@ -17,7 +17,9 @@ pub const Protocol = extern struct {
     }
 
     pub fn getName(self: Protocol) [:0]const u8 {
-        return std.mem.sliceTo(c.protocol_getName(self.value), 0);
+        const ptr = c.protocol_getName(self.value);
+        const len = std.mem.indexOfSentinel(u8, 0, ptr);
+        return ptr[0..len :0];
     }
 
     pub fn getProperty(

--- a/src/sel.zig
+++ b/src/sel.zig
@@ -19,7 +19,9 @@ pub const Sel = struct {
 
     /// Returns the name of the method specified by a given selector.
     pub fn getName(self: Sel) [:0]const u8 {
-        return std.mem.sliceTo(c.sel_getName(self.value), 0);
+        const ptr = c.sel_getName(self.value);
+        const len = std.mem.indexOfSentinel(u8, 0, ptr);
+        return ptr[0..len :0];
     }
 };
 


### PR DESCRIPTION
I chaged `@Type` to `@Fn` and `@Struct`, fixed `build.zig`, updated the code to the new `std.Io` and did some other minor things to make everything work on 0.16.